### PR TITLE
feat: add support for custom users

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -36,7 +36,7 @@ jobs:
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
         if: ${{ success() }} || ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: MegaLinter reports
           path: |

--- a/account.tf
+++ b/account.tf
@@ -33,13 +33,7 @@ resource "aws_iam_user" "iam_service_user" {
 }
 
 resource "aws_iam_user" "iam_custom_user" {
-  for_each = merge([ for key, account in local.accounts : { 
-    for username, policy in account.custom_users : "${key}-${username}" => {
-      username = username
-      policy   = policy  
-    }}
-    if account.custom_users != {}
-  ]...)
+  for_each = local.custom_account_users
 
   name = each.value.username
   path = "/accounts/"
@@ -48,14 +42,9 @@ resource "aws_iam_user" "iam_custom_user" {
 }
 
 resource "aws_iam_user_policy" "iam_custom_user" {
-  for_each = merge([ for key, account in local.accounts : { 
-    for username, policy in account.custom_users : "${key}-${username}" => {
-      username = username
-      policy   = policy  
-    }}
-    if account.custom_users != {}
-  ]...)
-  name   = "${each.value.username}-policy"
+  for_each = local.custom_account_users
+  
+  name   = "CustomUser-${each.value.username}"
   user   = each.value.username
   policy = each.value.policy
 }

--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,7 @@ locals {
           group           = {}
           user            = {}
           create_iam_user = false
+          custom_users    = {}
         }
         "Security tooling" = {
           email           = try(var.config.units["security"].accounts["Security tooling"].email, format(local.email_template, "security_tooling"))
@@ -28,6 +29,7 @@ locals {
           group           = {}
           user            = {}
           create_iam_user = false
+          custom_users    = {}
         }
       })
     })
@@ -45,6 +47,7 @@ locals {
           group           = {}
           user            = {}
           create_iam_user = false
+          custom_users    = {}
         }
         "Network" = {
           email           = try(var.config.units["infrastructure"].accounts["Network"].email, format(local.email_template, "network"))
@@ -53,6 +56,7 @@ locals {
           group           = {}
           user            = {}
           create_iam_user = false
+          custom_users    = {}
         }
       })
     })
@@ -70,6 +74,7 @@ locals {
           group           = {}
           user            = {}
           create_iam_user = false
+          custom_users    = {}
         }
       })
     })

--- a/main.tf
+++ b/main.tf
@@ -133,4 +133,12 @@ locals {
         try(entry.group[group], []),
       ) }
   }) }
+
+  custom_account_users = merge([ for key, account in local.accounts : { 
+    for username, policy in account.custom_users : "${key}-${username}" => {
+      username = username
+      policy   = policy  
+    }}
+    if account.custom_users != {}
+  ]...)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,7 @@ variable "config" {
         group           = optional(map(set(string)), {}) // key = group, value = permission_set
         user            = optional(map(set(string)), {}) // key = user, value = permission_set
         create_iam_user = optional(bool, false)
+        custom_users    = optional(map(string), {})          // key = username, value = user policy json
       })), {})
 
       children = optional(map(object({ // key = name
@@ -28,6 +29,7 @@ variable "config" {
           group           = optional(map(set(string)), {}) // key = group, value = permission_set
           user            = optional(map(set(string)), {}) // key = user, value = permission_set
           create_iam_user = optional(bool, false)
+          custom_users    = optional(map(string), {})          // key = username, value = user policy json
         })), {})
       })), {})
       })), {


### PR DESCRIPTION
Added field to account variable for specifying custom users that will be created by the root module. This makes it possible to create custom service users for specific services with a set permission set without having to allow the sub account access to create these users.